### PR TITLE
Don't normalize stings, check for object instead

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -106,7 +106,7 @@ function define(elementClass, def) {
           }
           else {
             var s = val.toString();
-            if (n.normalize) {
+            if (typeof n === 'object' && n.normalize) { //  see GH-491
               s = n.normalize(s);
             }
             this.setAttribute(attr, s);


### PR DESCRIPTION
Hello 👋

This PR adds a fix for the "argument does not match any normalization form" as seen in https://github.com/wordpress-mobile/gutenberg-mobile/pull/617#pullrequestreview-205427915.

It follows the same logic as in [line 95 earlier in the same file](https://github.com/iamcco/jsdom-jscore-rn/blob/master/lib/jsdom/level2/html.js#L95), guard the call to `n.normalize()` with a check for type `object`.

h/t to @koke for [spotting the bug](https://github.com/WordPress/gutenberg/pull/13983#issuecomment-465752970).