### PR TITLE
Fix TypeError: right operand of 'in' is not an object when calling querySelectorAll

### DIFF
--- a/lib/builtins/nwmatcher/src/nwmatcher-noqsa.js
+++ b/lib/builtins/nwmatcher/src/nwmatcher-noqsa.js
@@ -130,6 +130,7 @@
   },
 
   NATIVE_TRAVERSAL_API =
+    root &&
     'nextElementSibling' in root &&
     'previousElementSibling' in root,
 
@@ -280,10 +281,10 @@
       return elements;
     },
 
-  contains = 'compareDocumentPosition' in root ?
+  contains = root && 'compareDocumentPosition' in root ?
     function(container, element) {
       return (container.compareDocumentPosition(element) & 16) == 16;
-    } : 'contains' in root ?
+    } : root && 'contains' in root ?
     function(container, element) {
       return container !== element && container.contains(element);
     } :


### PR DESCRIPTION
Hi, I was consistently getting the error:
`TypeError: right operand of 'in' is not an object`
when calling `querySelectorAll()`.

I tracked down the problem to a couple of lines, which have been patched in this pull request.  The code assumes that a given variable contains an object, and attempts to iterate through its properties, but apparently, there are some circumstances in which the object does not exist and the variable is null or undefined.  Adding these simple safety checks helps to avoid the problem.

I hope this is helpful!